### PR TITLE
Add support for push event

### DIFF
--- a/src/comment.js
+++ b/src/comment.js
@@ -5,7 +5,9 @@ import { tabulate } from "./tabulate"
 
 export function comment (lcov, options) {
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		options.base
+			? `Coverage after merging ${b(options.head)} into ${b(options.base)}`
+			: `Coverage for this commit`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
@@ -29,7 +31,9 @@ export function diff(lcov, before, options) {
 				: "▴"
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		options.base
+			? `Coverage after merging ${b(options.head)} into ${b(options.base)}`
+			: `Coverage for this commit`,
 		table(tbody(tr(
 			th(pafter.toFixed(2), "%"),
 			th(arrow, " ", plus, pdiff.toFixed(2), "%"),

--- a/src/index.js
+++ b/src/index.js
@@ -23,22 +23,37 @@ async function main() {
 
 	const options = {
 		repository: context.payload.repository.full_name,
-		commit: context.payload.pull_request.head.sha,
 		prefix: `${process.env.GITHUB_WORKSPACE}/`,
-		head: context.payload.pull_request.head.ref,
-		base: context.payload.pull_request.base.ref,
+	}
+
+	if (context.eventName === "pull_request") {
+		options.commit = context.payload.pull_request.head.sha
+		options.head = context.payload.pull_request.head.ref
+		options.base = context.payload.pull_request.base.ref
+	} else if (context.eventName === "push") {
+		options.commit = context.payload.after
+		options.head = context.ref
 	}
 
 	const lcov = await parse(raw)
 	const baselcov = baseRaw && await parse(baseRaw)
 	const body = diff(lcov, baselcov, options)
 
-	await new GitHub(token).issues.createComment({
-		repo: context.repo.repo,
-		owner: context.repo.owner,
-		issue_number: context.payload.pull_request.number,
-		body: diff(lcov, baselcov, options),
-	})
+	if (context.eventName === "pull_request") {
+		await new GitHub(token).issues.createComment({
+			repo: context.repo.repo,
+			owner: context.repo.owner,
+			issue_number: context.payload.pull_request.number,
+			body: diff(lcov, baselcov, options),
+		})
+	} else if (context.eventName === "push") {
+		await new GitHub(token).repos.createCommitComment({
+			repo: context.repo.repo,
+			owner: context.repo.owner,
+			commit_sha: options.commit,
+			body: diff(lcov, baselcov, options),
+		})
+	}
 }
 
 main().catch(function(err) {


### PR DESCRIPTION
This PR will add support for the `push` event from github actions.
On a push event, the comment will be added directly to the commit instead of the pr.

closes #1 