### PR TITLE
Add statement coverage into tabulate

### DIFF
--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -4,6 +4,7 @@ import { th, tr, td, table, tbody, a, b, span, fragment } from "./html"
 export function tabulate(lcov, options) {
 	const head = tr(
 		th("File"),
+		th("Stmts"),
 		th("Branches"),
 		th("Funcs"),
 		th("Lines"),
@@ -40,9 +41,21 @@ function toFolder(path) {
 	return tr(td({ colspan: 5 }, b(path)))
 }
 
+function getStatement(file) {
+	const { branches, functions, lines } = file;
+	return [branches, functions, lines].reduce((prev, curr) => ({
+		hit: prev.hit + (curr.hit || 0),
+		found: prev.found + (curr.found || 0),
+	}), {
+		hit: 0,
+		found: 0,
+	})
+}
+
 function toRow(file, indent, options) {
 	return tr(
 		td(filename(file, indent, options)),
+		td(percentage(getStatement(file), options)),
 		td(percentage(file.branches, options)),
 		td(percentage(file.functions, options)),
 		td(percentage(file.lines, options)),


### PR DESCRIPTION
I wanted to make the comment match the same format as is produced by `clover.xml` and `lcov.info` report producing tools. So basically adding statement coverage into comment.

# Preview

![coverage](https://user-images.githubusercontent.com/7287118/94667063-fc2e7900-0316-11eb-8e6a-0bcc9451c8af.png)
