### PR TITLE
Add a default value for github-token input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Total Coverage: <b>99.39%</b>
 
 ## Inputs
 
-##### `github-token` (**Required**)
+##### `github-token` (**Optional**)
 Github token used for posting the comment. Defaults to `${{ github.token }}`.
 
 For alternative `github-token` values see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Total Coverage: <b>99.39%</b>
 
 ##### `github-token` (**Required**)
 Github token used for posting the comment. Defaults to `${{ github.token }}`.
-For alternative `github-token` see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+For alternative `github-token` value see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
 ##### `lcov-file` (**Optional**)
 The location of the lcov file to read the coverage report from. Defaults to

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Total Coverage: <b>99.39%</b>
 ## Inputs
 
 ##### `github-token` (**Required**)
-Github token used for posting the comment. To use the key provided by the GitHub
-action runner, use `${{ secrets.GITHUB_TOKEN }}`.
+Github token used for posting the comment. Defaults to `${{ github.token }}`.
+For alternative `github-token` see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
 ##### `lcov-file` (**Optional**)
 The location of the lcov file to read the coverage report from. Defaults to
@@ -32,7 +32,6 @@ branch. When this is set a diff of the coverage percentages is shown.
 ```yml
 uses: romeovs/lcov-reporter-action@v0.2.16
 with:
-  github-token: ${{ secrets.GITHUB_TOKEN }}
   lcov-file: ./coverage/lcov.info
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Total Coverage: <b>99.39%</b>
 ##### `github-token` (**Required**)
 Github token used for posting the comment. Defaults to `${{ github.token }}`.
 
-For alternative `github-token` value see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+For alternative `github-token` values see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
 ##### `lcov-file` (**Optional**)
 The location of the lcov file to read the coverage report from. Defaults to

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
   github-token:
     description: Github token
     required: true
+    default: ${{ github.token }}
   lcov-file:
     description: The location of the lcov.info file
     required: false


### PR DESCRIPTION
## Purpose
Allow users to skip redeclaring the default repo token each time.

This would now be required only when the token is different i.e Using a Personal Access Token.

@romeovs 