### PR TITLE
add working-directory input for href fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ Github token used for posting the comment. Defaults to `${{ github.token }}`.
 
 For alternative `github-token` values see: [Creating Personal Access Tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
+##### `working-directory` (**Default: ""**)
+Path to working directory the same as [default shell property](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun)
+
 ##### `lcov-file` (**Optional**)
 The location of the lcov file to read the coverage report from. Defaults to
-`./coverage/lcov.info`.
+`./coverage/lcov.info`. Path is relative to **working-directory** input
 
 ##### `lcov-base` (**Optional**)
 The location of the lcov file resulting from running the tests in the base

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Set to true to delete old Coverage Report comments
     required: false
     default: false
+  working-directory:
+    description: Set working directory if project is not in root folder  
+    required: false
+    default: "./"
   title:
     description: Title to add to the comment
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs"
 import core from "@actions/core"
 import { GitHub, context } from "@actions/github"
+import path from "path"
 
 import { parse } from "./lcov"
 import { diff } from "./comment"
@@ -13,7 +14,8 @@ const MAX_COMMENT_CHARS = 65536
 async function main() {
 	const token = core.getInput("github-token")
 	const githubClient = new GitHub(token)
-	const lcovFile = core.getInput("lcov-file") || "./coverage/lcov.info"
+	const workingDir = core.getInput('working-directory') || './';	
+	const lcovFile = path.join(workingDir, core.getInput("lcov-file") || "./coverage/lcov.info")
 	const baseFile = core.getInput("lcov-base")
 	const shouldFilterChangedFiles =
 		core.getInput("filter-changed-files").toLowerCase() === "true"
@@ -36,6 +38,7 @@ async function main() {
 	const options = {
 		repository: context.payload.repository.full_name,
 		prefix: normalisePath(`${process.env.GITHUB_WORKSPACE}/`),
+		workingDir,
 	}
 
 	if (context.eventName === "pull_request") {

--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -1,5 +1,5 @@
 import { th, tr, td, table, tbody, a, b, span, fragment } from "./html"
-import { normalisePath } from "./util"
+import { createHref, normalisePath } from "./util"
 
 // Tabulate the lcov data in a HTML table.
 export function tabulate(lcov, options) {
@@ -62,7 +62,7 @@ function getStatement(file) {
 	const { branches, functions, lines } = file
 
 	return [branches, functions, lines].reduce(
-		function(acc, curr) {
+		function (acc, curr) {
 			if (!curr) {
 				return acc
 			}
@@ -88,12 +88,9 @@ function toRow(file, indent, options) {
 }
 
 function filename(file, indent, options) {
-	const relative = file.file.replace(options.prefix, "")
-	const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`
-	const parts = relative.split("/")
-	const last = parts[parts.length - 1]
+	const {href, filename} = createHref(options, file);
 	const space = indent ? "&nbsp; &nbsp;" : ""
-	return fragment(space, a({ href }, last))
+	return fragment(space, a({ href }, filename))
 }
 
 function percentage(item) {
@@ -121,19 +118,18 @@ function uncovered(file, options) {
 	const all = ranges([...branches, ...lines])
 
 	return all
-		.map(function(range) {
+		.map(function (range) {
 			const fragment =
 				range.start === range.end
 					? `L${range.start}`
 					: `L${range.start}-L${range.end}`
-			const relative = file.file.replace(options.prefix, "")
-			const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#${fragment}`
+			const { href } = createHref(options, file)
 			const text =
 				range.start === range.end
 					? range.start
 					: `${range.start}&ndash;${range.end}`
 
-			return a({ href }, text)
+			return a({ href: `${href}#${fragment}` }, text)
 		})
 		.join(", ")
 }
@@ -143,7 +139,7 @@ function ranges(linenos) {
 
 	let last = null
 
-	linenos.sort().forEach(function(lineno) {
+	linenos.sort().forEach(function (lineno) {
 		if (last === null) {
 			last = { start: lineno, end: lineno }
 			return

--- a/src/tabulate_test.js
+++ b/src/tabulate_test.js
@@ -119,6 +119,7 @@ test("tabulate should generate a correct table", function() {
 		repository: "example/foo",
 		commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
 		prefix: "/files/project/",
+		workingDir: 'frontend'
 	}
 
 	const html = table(
@@ -135,7 +136,7 @@ test("tabulate should generate a correct table", function() {
 				td(
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/index.js`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/index.js`,
 						},
 						"index.js",
 					),
@@ -152,7 +153,7 @@ test("tabulate should generate a correct table", function() {
 					"&nbsp; &nbsp;",
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/foo.js`,
 						},
 						"foo.js",
 					),
@@ -164,7 +165,7 @@ test("tabulate should generate a correct table", function() {
 				td(
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js#L37`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/foo.js#L37`,
 						},
 						37,
 					),
@@ -176,7 +177,7 @@ test("tabulate should generate a correct table", function() {
 					"&nbsp; &nbsp;",
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/bar/baz.js`,
 						},
 						"baz.js",
 					),
@@ -188,14 +189,14 @@ test("tabulate should generate a correct table", function() {
 				td(
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L20-L21`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/bar/baz.js#L20-L21`,
 						},
 						"20&ndash;21",
 					),
 					", ",
 					a(
 						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L27`,
+							href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/bar/baz.js#L27`,
 						},
 						"27",
 					),
@@ -488,7 +489,7 @@ test("filtered tabulate should fix backwards slashes in filenames", function() {
 		shouldFilterChangedFiles: true,
 		changedFiles: ["src/foo.js"],
 	}
-
+	
 	const html = table(
 		tbody(
 			tr(

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,16 @@
+import path from 'path'
+
 export function normalisePath(file) {
 	return file.replace(/\\/g, "/")
+}
+
+export function createHref(options, file) {
+	const relative = file.file.replace(options.prefix, "")
+	const parts = relative.split("/")
+	const filename = parts[parts.length - 1]
+	const url = path.join(options.repository, 'blob', options.commit, options.workingDir || './', relative)
+	return {
+		href: `https://github.com/${url}`,
+		filename
+	};
 }

--- a/src/util_test.js
+++ b/src/util_test.js
@@ -1,0 +1,87 @@
+import { createHref } from "./util"
+
+test('create simple url to file', () => {
+  const options = {
+    repository: "example/foo",
+    commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+    prefix: "/files/project/",
+  }
+  const file = {
+    file: "/files/project/index.js",
+    functions: {
+      found: 0,
+      hit: 0,
+      details: [],
+    },
+  }
+  expect(createHref(options, file)).toEqual({
+    href: `https://github.com/${options.repository}/blob/${options.commit}/index.js`,
+    filename: 'index.js'
+  })
+})
+
+describe('has working directory', () => {
+  test('create url to file with simple working dir path', () => {
+    const options = {
+      repository: "example/foo",
+      commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+      prefix: "/files/project/",
+      workingDir: 'frontend'
+    }
+    const file = {
+      file: "/files/project/index.js",
+      functions: {
+        found: 0,
+        hit: 0,
+        details: [],
+      },
+    }
+    expect(createHref(options, file)).toEqual({
+      href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/index.js`,
+      filename: 'index.js'
+    })
+  })
+
+  test('working dir relative path', () => {
+    const options = {
+      repository: "example/foo",
+      commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+      prefix: "/files/project/",
+      workingDir: './frontend/'
+    }
+    const file = {
+      file: "/files/project/index.js",
+      functions: {
+        found: 0,
+        hit: 0,
+        details: [],
+      },
+    }
+    expect(createHref(options, file)).toEqual({
+      href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/index.js`,
+      filename: 'index.js'
+    })
+  })
+
+  test('working dir path with leading and trailing slashed', () => {
+    const options = {
+      repository: "example/foo",
+      commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+      prefix: "/files/project/",
+      workingDir: '/frontend/'
+    }
+    const file = {
+      file: "/files/project/src/foo.js",
+      functions: {
+        found: 0,
+        hit: 0,
+        details: [],
+      },
+    }
+    expect(createHref(options, file)).toEqual({
+      href: `https://github.com/${options.repository}/blob/${options.commit}/frontend/src/foo.js`,
+      filename: 'foo.js'
+    })
+  })
+
+})


### PR DESCRIPTION
add **working-directory** input similar to default shell input https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
needed for fixing href paths inside table