### PR TITLE
bump nodejs 12 to 16, since it's deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: Title to add to the comment
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/main.js


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/