### PR TITLE
fix Empty value for parameter 'issue_number': undefined

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: Title to add to the comment
     required: false
 runs:
-  using: node16
+  using: 'node20'
   main: dist/main.js

--- a/dist/main.js
+++ b/dist/main.js
@@ -23099,7 +23099,7 @@ const MAX_COMMENT_CHARS = 65536;
 async function main$1() {
 	const token = core$1.getInput("github-token");
 	const githubClient = new github_2(token);
-	const workingDir = core$1.getInput('working-directory') || './';	
+	const workingDir = core$1.getInput('working-directory') || './';
 	const lcovFile = path.join(workingDir, core$1.getInput("lcov-file") || "./coverage/lcov.info");
 	const baseFile = core$1.getInput("lcov-base");
 	const shouldFilterChangedFiles =
@@ -23148,11 +23148,10 @@ async function main$1() {
 	const baselcov = baseRaw && (await parse$2(baseRaw));
 	const body = diff(lcov, baselcov, options).substring(0, MAX_COMMENT_CHARS);
 
-	if (shouldDeleteOldComments) {
-		await deleteOldComments(githubClient, options, github_1);
-	}
-
 	if (github_1.eventName === "pull_request") {
+		if (shouldDeleteOldComments) {
+			await deleteOldComments(githubClient, options, github_1);
+		}
 		await githubClient.issues.createComment({
 			repo: github_1.repo.repo,
 			owner: github_1.repo.owner,

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const MAX_COMMENT_CHARS = 65536
 async function main() {
 	const token = core.getInput("github-token")
 	const githubClient = new GitHub(token)
-	const workingDir = core.getInput('working-directory') || './';	
+	const workingDir = core.getInput('working-directory') || './';
 	const lcovFile = path.join(workingDir, core.getInput("lcov-file") || "./coverage/lcov.info")
 	const baseFile = core.getInput("lcov-base")
 	const shouldFilterChangedFiles =
@@ -63,11 +63,10 @@ async function main() {
 	const baselcov = baseRaw && (await parse(baseRaw))
 	const body = diff(lcov, baselcov, options).substring(0, MAX_COMMENT_CHARS)
 
-	if (shouldDeleteOldComments) {
-		await deleteOldComments(githubClient, options, context)
-	}
-
 	if (context.eventName === "pull_request") {
+		if (shouldDeleteOldComments) {
+			await deleteOldComments(githubClient, options, context)
+		}
 		await githubClient.issues.createComment({
 			repo: context.repo.repo,
 			owner: context.repo.owner,


### PR DESCRIPTION
The action fails on commits to a branch - as opposed to a PR - with `RequestError [HttpError]: Empty value for parameter 'issue_number': undefined`. 

Fixes #33 . 

This was also fixed by others, like https://github.com/CayabaCare/lcov-reporter-action/commit/c81818cd90cb309ec0c3d07feec613ccb1ce92c9 - but I couldn't find a current PR. Here it is.