### PR TITLE
Support pull_request_target event type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ async function main() {
 		workingDir,
 	}
 
-	if (context.eventName === "pull_request") {
+	if (context.eventName === "pull_request" || context.eventName === "pull_request_target") {
 		options.commit = context.payload.pull_request.head.sha
 		options.baseCommit = context.payload.pull_request.base.sha
 		options.head = context.payload.pull_request.head.ref
@@ -67,7 +67,7 @@ async function main() {
 		await deleteOldComments(githubClient, options, context)
 	}
 
-	if (context.eventName === "pull_request") {
+	if (context.eventName === "pull_request" || context.eventName === "pull_request_target") {
 		await githubClient.issues.createComment({
 			repo: context.repo.repo,
 			owner: context.repo.owner,


### PR DESCRIPTION
The `pull_request_target` event is an alternative to the `pull_request` event but with some different security considerations. [Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

We use it on private repositories to allow dependabot access to our secrets, safe in the knowledge that a private repo can't expose our secrets to drive-by malicious PRs.

This is a simple change that extends the logic for "pull_request" to "pull_request_target" for comparisons of changes, etc.