### PR TITLE
Respect workingDirectory on extracting git changed files

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -23047,9 +23047,13 @@ async function getChangedFiles(githubClient, options, context) {
 		);
 	}
 
+	// Normalize the working directory path from './' to '' or './src' to 'src'
+	const workingDir = options.workingDir.replace(/^.\//, "");
+
+	// Return the list of changed files, removing the working directory prefix and starting slash.
 	return response.data.files
 		.filter(file => file.status == "modified" || file.status == "added")
-		.map(file => file.filename)
+		.map(file => file.filename.replace(workingDir, "").replace(/^\//, ""))
 }
 
 const REQUESTED_COMMENTS_PER_PAGE = 20;

--- a/src/get_changes.js
+++ b/src/get_changes.js
@@ -23,7 +23,11 @@ export async function getChangedFiles(githubClient, options, context) {
 		)
 	}
 
+	// Normalize the working directory path from './' to '' or './src' to 'src'
+	const workingDir = options.workingDir.replace(/^.\//, "")
+
+	// Return the list of changed files, removing the working directory prefix and starting slash.
 	return response.data.files
 		.filter(file => file.status == "modified" || file.status == "added")
-		.map(file => file.filename)
+		.map(file => file.filename.replace(workingDir, "").replace(/^\//, ""))
 }

--- a/src/get_changes_test.js
+++ b/src/get_changes_test.js
@@ -1,0 +1,116 @@
+import { getChangedFiles } from "./get_changes"
+import * as core from "@actions/core"
+
+jest.mock("@actions/core")
+
+describe("getChangedFiles", () => {
+	let mockGithubClient
+
+	beforeEach(() => {
+		mockGithubClient = {
+			repos: {
+				compareCommits: jest.fn(),
+			},
+		}
+		core.setFailed = jest.fn()
+	})
+
+	it("should fail if commit or baseCommit is missing", async () => {
+		const options = { workingDir: "./" }
+		const context = {
+			eventName: "push",
+			repo: { owner: "owner", repo: "repo" },
+		}
+
+		mockGithubClient.repos.compareCommits.mockResolvedValue({
+			status: 500,
+			data: {
+        files: [],
+      },
+		})
+
+		await getChangedFiles(mockGithubClient, options, context)
+
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"The base and head commits are missing from the payload for this push event.",
+		)
+	})
+
+	it("should fail on non-200 response from GitHub API", async () => {
+		const options = {
+			commit: "headSha",
+			baseCommit: "baseSha",
+			workingDir: "./",
+		}
+		const context = {
+			eventName: "push",
+			repo: { owner: "owner", repo: "repo" },
+		}
+
+		mockGithubClient.repos.compareCommits.mockResolvedValue({
+			status: 404,
+			data: {
+        files: [],
+      },
+		})
+
+		await getChangedFiles(mockGithubClient, options, context)
+
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"The GitHub API for comparing the base and head commits for this push event returned 404, expected 200.",
+		)
+	})
+
+	it("should return a list of modified and added files", async () => {
+		const options = {
+			commit: "headSha",
+			baseCommit: "baseSha",
+			workingDir: "./src",
+		}
+		const context = {
+			eventName: "push",
+			repo: { owner: "owner", repo: "repo" },
+		}
+
+		mockGithubClient.repos.compareCommits.mockResolvedValue({
+			status: 200,
+			data: {
+				files: [
+					{ status: "modified", filename: "src/file1.js" },
+					{ status: "added", filename: "src/file2.js" },
+					{ status: "removed", filename: "src/file3.js" },
+				],
+			},
+		})
+
+		const result = await getChangedFiles(mockGithubClient, options, context)
+
+		expect(result).toEqual(["file1.js", "file2.js"])
+	})
+
+	it("should correctly normalize working directory", async () => {
+		const options = {
+			commit: "headSha",
+			baseCommit: "baseSha",
+			workingDir: "./",
+		}
+		const context = {
+			eventName: "push",
+			repo: { owner: "owner", repo: "repo" },
+		}
+
+		mockGithubClient.repos.compareCommits.mockResolvedValue({
+			status: 200,
+			data: {
+				files: [
+					{ status: "modified", filename: "/file1.js" },
+					{ status: "added", filename: "/file2.js" },
+				],
+			},
+		})
+
+		const result = await getChangedFiles(mockGithubClient, options, context)
+
+		expect(result).toEqual(["file1.js", "file2.js"])
+	})
+})


### PR DESCRIPTION
The current filter-changed-files does not work with monorepo (see issue [here](https://github.com/romeovs/lcov-reporter-action/issues/69))

The reason behind is that:
- jest test is usually under subfolder like packages/a, and the coverage will be generated along in the root directory of jest by default
- The file change detection based on git, which will be in the root of the git repo
- Such that the file path in test coverage file will never matches the file path in git compare

There are different ways to fix but the most intuitive one will be respecting the working directory we set in the GitHub action config when we get the changed file names from git compare