### PR TITLE
Upgrade from end of life and deprecated Node 16 to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: Title to add to the comment
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/main.js


### PR DESCRIPTION
More context: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 👍 

> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024.